### PR TITLE
`file_exists()` check with retry logic

### DIFF
--- a/ckanext/searchterms/click.py
+++ b/ckanext/searchterms/click.py
@@ -36,9 +36,9 @@ def submit(dataset_spec, fg):
     if dataset_spec == "all":
         cmd.submit_all_pkgs()
     else:
-        pkg_id = cmd.identify_pkg(dataset_spec)
-        if pkg_id:
-            cmd.resubmit_pkg(pkg_id)
+        dataset = cmd.identify_pkg(dataset_spec)
+        if dataset:
+            cmd.resubmit_pkg(dataset)
 
 
 def get_commands():

--- a/ckanext/searchterms/plugin.py
+++ b/ckanext/searchterms/plugin.py
@@ -12,7 +12,12 @@ from .jobs import (
     enqueue_terms_job,
     enqueue_terms_update_on_delete_job,
 )
-from .util import TERMS_RSRC_NAME, file_exists, get_resource_file_path, site_user_context
+from .util import (
+    TERMS_RSRC_NAME,
+    file_exists,
+    get_resource_file_path,
+    site_user_context,
+)
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/searchterms/plugin.py
+++ b/ckanext/searchterms/plugin.py
@@ -12,7 +12,7 @@ from .jobs import (
     enqueue_terms_job,
     enqueue_terms_update_on_delete_job,
 )
-from .util import TERMS_RSRC_NAME, get_resource_file_path, site_user_context
+from .util import TERMS_RSRC_NAME, file_exists, get_resource_file_path, site_user_context
 
 log = logging.getLogger(__name__)
 
@@ -55,32 +55,38 @@ class SearchtermsPlugin(plugins.SingletonPlugin):
         pkg = tk.get_action("package_show")(
             site_user_context(), {"id": pkg_dict.get("id")}
         )
-        try:
-            filteredResources = list(
-                filter(
-                    lambda rsrc: rsrc.get("name") == TERMS_RSRC_NAME,
-                    pkg.get("resources", []),
-                )
+        filteredResources = list(
+            filter(
+                lambda rsrc: rsrc.get("name") == TERMS_RSRC_NAME,
+                pkg.get("resources", []),
             )
-            if len(filteredResources):
-                genes = filteredResources[0]
-                df = pd.read_csv(get_resource_file_path(genes.get("id")), sep="\t")
-                data = df.values.flatten().tolist()
-                hundreds = math.ceil(len(data) / float(100))
-                for i in range(int(hundreds)):
+        )
+        if len(filteredResources):
+            searchterms_resource_id = filteredResources[0].get("id")
+            try:
+                if file_exists(searchterms_resource_id):
+                    df = pd.read_csv(
+                        get_resource_file_path(searchterms_resource_id), sep="\t"
+                    )
+                    data = df.values.flatten().tolist()
+                    hundreds = math.ceil(len(data) / float(100))
+                    for i in range(int(hundreds)):
 
-                    def upper_bound(proposed, max_len=len(data)):
-                        return max_len if proposed > max_len else proposed
+                        def upper_bound(proposed, max_len=len(data)):
+                            return max_len if proposed > max_len else proposed
 
-                    key = pkg.get("id") + "_search_term_" + str(i)
-                    min = int(i * 100)
-                    max = upper_bound((i + 1) * 100)
-                    data_slice = data[min:max]
-                    pkg_dict["extras_" + key] = json.dumps(data_slice)
-        except Exception:
-            err_msg = "An error occurred in building the index for package {0}"
-            log.error(err_msg.format(pkg.get("name")))
-            raise
+                        key = pkg.get("id") + "_search_term_" + str(i)
+                        min = int(i * 100)
+                        max = upper_bound((i + 1) * 100)
+                        data_slice = data[min:max]
+                        pkg_dict["extras_" + key] = json.dumps(data_slice)
+                else:
+                    log.error("Search terms resource exists but file does not.")
+            except Exception:
+                err_msg = "An error occurred in building the index for package {0}"
+                log.error(err_msg.format(pkg.get("name")))
+                raise
+
         return pkg_dict
 
     # IConfigurer

--- a/ckanext/searchterms/tests/test_util.py
+++ b/ckanext/searchterms/tests/test_util.py
@@ -6,10 +6,11 @@ import pathlib
 from ckanext.searchterms.util import get_resource_file_path
 from ckanext.searchterms.plugin import file_exists
 
-def test_file_exists(app):
-    """ Test the utility function `file_exists` """
 
-    os.environ['CKAN_STORAGE_PATH'] = "/tmp"
+def test_file_exists(app):
+    """Test the utility function `file_exists`"""
+
+    os.environ["CKAN_STORAGE_PATH"] = "/tmp"
     resource_id = "abcdefmytest"
 
     # Delete file if it exists from previous test run

--- a/ckanext/searchterms/tests/test_util.py
+++ b/ckanext/searchterms/tests/test_util.py
@@ -1,0 +1,33 @@
+"""Tests for util.py."""
+import pytest
+import os
+
+import pathlib
+from ckanext.searchterms.util import get_resource_file_path
+from ckanext.searchterms.plugin import file_exists
+
+def test_file_exists(app):
+    """ Test the utility function `file_exists` """
+
+    resource_id = "abcdefmytest"
+
+    # Delete file if it exists from previous test run
+    fpath = get_resource_file_path(resource_id)
+    if os.path.exists(fpath):
+        os.remove(fpath)
+
+    # Verify file does not exist
+    resource_id = "abcdefmytest"
+    result = file_exists(resource_id, delay=0)
+    assert result == False
+
+    # Create test file at path
+    dirpath = fpath.rsplit("/", 1)[0]
+    pathlib.Path(dirpath).mkdir(parents=True, exist_ok=True)
+    testFile = open(fpath, "w")
+    testFile.write("mytest")
+    testFile.close()
+
+    # Verify file does exist
+    result2 = file_exists(resource_id, delay=0)
+    assert result2 == True

--- a/ckanext/searchterms/tests/test_util.py
+++ b/ckanext/searchterms/tests/test_util.py
@@ -9,6 +9,7 @@ from ckanext.searchterms.plugin import file_exists
 def test_file_exists(app):
     """ Test the utility function `file_exists` """
 
+    os.environ['CKAN_STORAGE_PATH'] = "/tmp"
     resource_id = "abcdefmytest"
 
     # Delete file if it exists from previous test run

--- a/ckanext/searchterms/util.py
+++ b/ckanext/searchterms/util.py
@@ -12,6 +12,7 @@ BLANK = ""
 
 log = logging.getLogger(__name__)
 
+
 def get_resource_file_path(id):
     dir1 = id[0:3]
     dir2 = id[3:6]
@@ -22,6 +23,7 @@ def get_resource_file_path(id):
 def site_user_context():
     user = tk.get_action("get_site_user")({"model": model, "ignore_auth": True}, {})
     return {"ignore_auth": True, "user": user["name"], "auth_user_obj": None}
+
 
 def file_exists(resource_id, num_retries=3, delay=0.5):
     # Sometimes after the file was uploaded to CKAN, it takes a second for it to exist

--- a/ckanext/searchterms/util.py
+++ b/ckanext/searchterms/util.py
@@ -1,4 +1,6 @@
 import os
+import time
+import logging
 
 from ckan import model
 import ckan.plugins.toolkit as tk
@@ -8,6 +10,7 @@ TERMS_RSRC_NAME = "Search Terms"
 TRUE = True
 BLANK = ""
 
+log = logging.getLogger(__name__)
 
 def get_resource_file_path(id):
     dir1 = id[0:3]
@@ -19,3 +22,16 @@ def get_resource_file_path(id):
 def site_user_context():
     user = tk.get_action("get_site_user")({"model": model, "ignore_auth": True}, {})
     return {"ignore_auth": True, "user": user["name"], "auth_user_obj": None}
+
+def file_exists(resource_id, num_retries=3, delay=0.5):
+    # Sometimes after the file was uploaded to CKAN, it takes a second for it to exist
+    for try_num in range(0, num_retries):
+        if os.path.exists(get_resource_file_path(resource_id)):
+            log.info("File exists")
+            return True
+        elif try_num + 1 != num_retries:
+            log.info(
+                "Retrying file_exists({}) (retry {})".format(resource_id, try_num + 1)
+            )
+            time.sleep(delay)
+    return False


### PR DESCRIPTION
### Reason for change

As written in the comment for util.py:

> Sometimes after the file was uploaded to CKAN, it takes a second for it to exist

I haven't seen this in dev, but in production:
```
ERROR [ckanext.searchterms.plugin:82] An error occurred in building the index for package fecal-metagenomic-profiles-in-subgroups-of-patients-with-me-cfs
ERROR [ckan.lib.search:110] [Errno 2] No such file or directory: '/srv/app/data/resources/609/5b8/41-41d7-48e7-8241-8d62695c6e84'
```

But when I checked, the file _did_ exist, so I'm thinking it may just need a second of delay.

### How does your code work (if non-trivial)?

Resiliently check if the file exists before trying to read it.