### PR TITLE
Format dataframe to str type

### DIFF
--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -122,6 +122,7 @@ def update_searchterms(rsrc_col, new_terms_df, key, searchterms_df):
 
     # Add a new column to the searchterms DataFrame and initialize all rows to BLANK
     searchterms_df[rsrc_col] = BLANK
+    searchterms_df = searchterms_df.astype(str)
 
     # If there are existing terms we need to update rows for, do so
     existing_terms_df = new_terms_df[


### PR DESCRIPTION
### Reason for change
Certain datasets were breaking search terms when the column values were being lowercased:
```
2022-02-03 18:57:21,541 ERROR [ckan.lib.jobs:289] Job 6f90ebcb-9337-470f-ae75-11e1d1a6c2a4 on worker rq:worker:457a5cac5fbf4762aedf70a93da05d18 raised an exception: 'float' object has no attribute 'lower'
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/rq/worker.py", line 812, in perform_job
    rv = job.perform()
  File "/usr/local/lib/python3.8/dist-packages/rq/job.py", line 588, in perform
    self._result = self._execute()
  File "/usr/local/lib/python3.8/dist-packages/rq/job.py", line 594, in _execute
    return self.func(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.8/dist-packages/ckanext/searchterms/jobs.py", line 103, in check_search_terms_resource
    searchterms_df = update_searchterms(rsrc_col, new_terms_df, key, searchterms_df)
  File "/usr/local/lib/python3.8/dist-packages/ckanext/searchterms/jobs.py", line 132, in update_searchterms
    if row[key].lower() in existing_terms_df[key].str.lower().values:
AttributeError: 'float' object has no attribute 'lower'
```

### How does your code work (if non-trivial)?
Added a line of code to format the dataframe to string dtypes.
