### PR TITLE
Make searchterms_error a resource field not dataset field

### DIFF
--- a/ckanext/searchterms/click.py
+++ b/ckanext/searchterms/click.py
@@ -24,7 +24,7 @@ def searchterms():
 
 
 @searchterms.command()
-@click.argument(u"dataset-spec")
+@click.argument("dataset-spec")
 @click.option(
     "--fg", is_flag=True, default=False, help="Runs the gene tagger in the foreground"
 )

--- a/ckanext/searchterms/command.py
+++ b/ckanext/searchterms/command.py
@@ -70,7 +70,7 @@ class SearchtermsCmd:
                         check_search_terms_resource,
                         [resource, True],
                         rq_kwargs={"timeout": 21600},
-                        queue=u"searchterms",
+                        queue="searchterms",
                     )
             else:
                 log.debug("Skipping search terms job for resource " + rsrcid)

--- a/ckanext/searchterms/interfaces.py
+++ b/ckanext/searchterms/interfaces.py
@@ -8,14 +8,14 @@ class ISearchterms(Interface):
     """
 
     def is_eligible_for_searchterms(self, resource):
-        u"""
+        """
         Returns a boolean that is used to determine if search terms should be
         generated for the given resource.
         """
         return False
 
     def get_searchterms(self, resource, dataset, existing_terms):
-        u"""
+        """
         Returns a pandas.DataFrame with columns containing terms.
         Multiple columns denotes synonyms.
         """

--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -93,7 +93,7 @@ def check_search_terms_resource(resource, resource_was_updated=False):
     try:
         new_terms_df, key = get_terms(resource, dataset, searchterms_df)
     except SearchtermsParsingError as e:
-        return add_error(dataset, str(e))
+        return add_error(resource, str(e))
     if searchterms_df is not None:
         # Update existing searchterms DataFrame.
         # If the resource was updated and already exists in the searchterms DataFrame, remove it
@@ -238,7 +238,7 @@ def delete_existing_search_terms(resource):
             tk.get_action("resource_delete")(site_user_context(), res)
 
 
-def add_error(dataset, e):
-    errormessage = "Unable to process your data file for search. Error: {}".format(e)
-    dataset[SEARCHTERMS_ERROR] = errormessage
-    tk.get_action("package_update")(site_user_context(), dataset)
+def add_error(resource, e):
+    errormessage = "Unable to process your resource for search. Error: {}".format(e)
+    resource[SEARCHTERMS_ERROR] = errormessage
+    tk.get_action("resource_update")(site_user_context(), resource)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -60,7 +60,18 @@ When a dataset's resource is created or updated, searchterms will call `is_eligi
 
 ## Schema
 
-The searchterms plugin will set the field `searchterms_error` on the dataset if there is an error. This field must be added to your dataset schema if you want it available on the dataset.
+The searchterms plugin will set the field `searchterms_error` on the resource if there is an error. This field must be added to your dataset schema if you want it available on the resource.
+
+```
+{
+    "resource_fields": [
+        {
+            "field_name": "searchterms_error",
+            "validators": "ignore_missing"
+        }
+    ]
+}
+```
 
 ## What sort of search terms might be generated?
 


### PR DESCRIPTION
### Reason for change

`searchterms_error` applies to a particular resource, not the entire dataset