### PR TITLE
New search terms poc tests

### DIFF
--- a/ckanext/searchterms/click.py
+++ b/ckanext/searchterms/click.py
@@ -24,7 +24,7 @@ def searchterms():
 
 
 @searchterms.command()
-@click.argument(u"dataset-spec")
+@click.argument("dataset-spec")
 @click.option(
     "--fg", is_flag=True, default=False, help="Runs the gene tagger in the foreground"
 )

--- a/ckanext/searchterms/command.py
+++ b/ckanext/searchterms/command.py
@@ -70,7 +70,7 @@ class SearchtermsCmd:
                         check_search_terms_resource,
                         [resource, True],
                         rq_kwargs={"timeout": 21600},
-                        queue=u"searchterms",
+                        queue="searchterms",
                     )
             else:
                 log.debug("Skipping search terms job for resource " + rsrcid)

--- a/ckanext/searchterms/interfaces.py
+++ b/ckanext/searchterms/interfaces.py
@@ -8,14 +8,14 @@ class ISearchterms(Interface):
     """
 
     def is_eligible_for_searchterms(self, resource):
-        u"""
+        """
         Returns a boolean that is used to determine if search terms should be
         generated for the given resource.
         """
         return False
 
     def get_searchterms(self, resource, dataset, existing_terms):
-        u"""
+        """
         Returns a pandas.DataFrame with columns containing terms.
         Multiple columns denotes synonyms.
         """

--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -144,13 +144,14 @@ def update_searchterms(rsrc_col, new_terms_df, searchterms_df):
 # But it first loops through all rows of the searchterms table, removing any if unused by other resources
 def remove_resource_from_search_terms(rsrc_col, searchterms_df):
     log.info("Update detected - removing old search terms for this resource")
+    rsrc_id = f"rsrc-{rsrc_col}" if "rsrc" not in rsrc_col else rsrc_col
     # remove old column
-    searchterms_df.drop(columns=[rsrc_col], inplace=True)
+    searchterms_df.drop(columns=[rsrc_id], inplace=True)
     # drop any rows that should no longer exist because that column is gone
     rsrc_cols = [
-        column for column in searchterms_df.columns.values.tolist() if "rsrc" in column
+        column for column in searchterms_df.columns if "rsrc" in column
     ]
-    searchterms_df.dropna(axis="rows", how="all", subset=[rsrc_cols], inplace=True)
+    searchterms_df.dropna(how="all", subset=rsrc_cols, inplace=True)
     return searchterms_df
 
 


### PR DESCRIPTION
### Reason for change
Updating code to provide expected output for searchterms and remove error related to deleting rows after removing a resource.
Code where error was taking place:
```
searchterms_df.dropna(axis="rows", how="all", subset=[rsrc_cols], inplace=True)
```
Error:
```
IndexError: boolean index did not match indexed array along dimension 0; dimension is 1 but corresponding boolean dimension is 5
```
This was caused from wrapping the `rsrc_cols` list in another list.

### How does your code work (if non-trivial)?
Automatically prefixes the resource id with "rsrc-" when dropping columns. Drops rows that contain only`NaN` values for the resource columns, using a list instead of a nested list.
