### PR TITLE
Clean up most of the extra |'s in the search_index col

### DIFF
--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -229,12 +229,12 @@ def add_search_index_to_search_terms(searchterms_df):
     """
     if "search_index" in searchterms_df.columns:
         searchterms_df.drop(columns=["search_index"], inplace=True)
-    searchterms_df.fillna("")
+    searchterms_df.fillna("", inplace=True)
     indexable_cols = get_termcols(searchterms_df) + get_identifiercols(searchterms_df)
     searchterms_df["search_index"] = (
         searchterms_df[indexable_cols]
         .agg("||".join, axis=1)
-        .replace(regex=r"[|]{3,}", value="||", inplace=True)
+        .replace(regex=r"[|]{3,}", value="||")
     )
     return searchterms_df
 


### PR DESCRIPTION
### Reason for change
Cleans up extra `|` characters in the "search_index" column. We could clean up further by adding `replace(regex=r"^[|]{2}", value="", inplace=True)` on to the end.

### How does your code work (if non-trivial)?

