### PR TITLE
Manually set column order when updating search terms

### DIFF
--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -99,6 +99,8 @@ def check_search_terms_resource(resource, resource_was_updated=False):
             searchterms_df = remove_resource_from_search_terms(rsrc_col, searchterms_df)
         searchterms_df = update_searchterms(rsrc_col, new_terms_df, searchterms_df)
         delete_existing_search_terms(resource)
+        new_column_order = [*get_identifiercols(searchterms_df), *get_termcols(searchterms_df), *get_rsrccols(searchterms_df), "search_index"]
+        searchterms_df = searchterms_df[new_column_order]
     else:
         searchterms_df = new_terms_df
     searchterms_df = add_search_index_to_search_terms(searchterms_df)

--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -99,7 +99,12 @@ def check_search_terms_resource(resource, resource_was_updated=False):
             searchterms_df = remove_resource_from_search_terms(rsrc_col, searchterms_df)
         searchterms_df = update_searchterms(rsrc_col, new_terms_df, searchterms_df)
         delete_existing_search_terms(resource)
-        new_column_order = [*get_identifiercols(searchterms_df), *get_termcols(searchterms_df), *get_rsrccols(searchterms_df), "search_index"]
+        new_column_order = [
+            *get_identifiercols(searchterms_df),
+            *get_termcols(searchterms_df),
+            *get_rsrccols(searchterms_df),
+            "search_index",
+        ]
         searchterms_df = searchterms_df[new_column_order]
     else:
         searchterms_df = new_terms_df


### PR DESCRIPTION
### Reason for change
This fixes a bug that causes the search terms columns to get out of order when rerunning search terms tagging.

### How does your code work (if non-trivial)?
Manually sets the order of the columns when updating the search terms
