### PR TITLE
Missing files fix

### DIFF
--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -213,11 +213,11 @@ def upload_to_ckan(filepath, name, dataset_id):
             )
         )
 
-    updatedPackage = tk.get_action("package_show")(
-        site_user_context(), {"id": dataset_id}
+    # After uploading searchterms resource, clear any searchterms error message
+    final = tk.get_action("package_revise")(
+        site_user_context(),
+        {"match": {"id": dataset_id}, "update": {SEARCHTERMS_ERROR: BLANK}},
     )
-    updatedPackage[SEARCHTERMS_ERROR] = BLANK
-    final = tk.get_action("package_update")(site_user_context(), updatedPackage)
     return final
 
 


### PR DESCRIPTION
### Reason for change
User reported older files being replaced when uploading multiple files. Steps to easily reproduce this: 
1. Create a new Gene Expression dataset with only phenotype file (no data files yet) 
2. Open dataset and select "Add new file" 
3. Add at least three data files quickly and sequentially

Result: some file(s) will disappear randomly with no specific order with higher frequency when adding many data files. The files will have been uploaded successfully and entries are made in the CKAN DB resources table but marked as "deleted." 
### How does your code work (if non-trivial)?
Logging shows `package_update` calls were being made with the newest resources omitted from the package dict from `package_show`. Additional digging shows this is a known issue with concurrent `package_update` `resource_create` calls etc. CKAN's recommendation is to use `package_revise` exclusively if we are doing concurrent calls (searchterms + xloader), which seemed to have fixed this issue or at least reduced the frequency significantly. Will be submitting the xloader branch shortly after.
References:
https://github.com/ckan/ckan/pull/4618
https://github.com/ckan/ckan/issues/5225