### PR TITLE
filter index terms and set dtype to str

### DIFF
--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -17,6 +17,7 @@ from .util import (
 
 log = logging.getLogger(__name__)
 
+
 # If resource is eligible, add terms job to worker queue
 def enqueue_terms_job(resource):
     # Check package_id exists to make sure it's not a package

--- a/ckanext/searchterms/plugin.py
+++ b/ckanext/searchterms/plugin.py
@@ -67,11 +67,20 @@ class SearchtermsPlugin(plugins.SingletonPlugin):
             )
         )
         if len(filteredResources):
+
+            def is_valid_string(value):
+                return isinstance(value, str) and value.strip() not in [
+                    "True",
+                    "False",
+                    "",
+                ]
+
             fpath = get_resource_file_path(filteredResources[0].get("id"))
             if exists(fpath):
                 try:
-                    df = pd.read_csv(fpath, sep="\t")
-                    data = df.values.flatten().tolist()
+                    df = pd.read_csv(fpath, sep="\t", dtype=str)
+                    all_data = df.values.flatten().tolist()
+                    data = [item for item in all_data if is_valid_string(item)]
                     hundreds = math.ceil(len(data) / float(100))
                     for i in range(int(hundreds)):
 

--- a/ckanext/searchterms/tests/test_plugin.py
+++ b/ckanext/searchterms/tests/test_plugin.py
@@ -1,4 +1,5 @@
 """Tests for plugin.py."""
+
 import pytest
 
 from ckanext.searchterms.implementations import (


### PR DESCRIPTION
### Reason for change
When rebuilding search index, sometimes this warning message is displayed: 
`DtypeWarning: Columns (19,20,21,22,23,24,25,26,27,28,29) have mixed types. Specify dtype option on import or set low_memory=False.` In addition, the indexing function does not filter for `True', 'False', and nan's which depending on the data file can be the bulk of the Search Term values

### How does your code work (if non-trivial)?
Sets dtype to str when loading Search Term file. Also filters data for any True, False, and nan values before sending to SOLR for indexing. 