### PR TITLE
Searchterms task status db updates and previews fix

### DIFF
--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -10,7 +10,6 @@ from .util import (
     BLANK,
     SEARCHTERMS_ERROR,
     TERMS_RSRC_NAME,
-    TRUE,
     get_resource_file_path,
     site_user_context,
 )
@@ -243,6 +242,24 @@ def upload_to_ckan(filepath, name, dataset_id):
                 name, dataset_id
             )
         )
+        pkg = tk.get_action("package_show")(site_user_context(), {"id": dataset_id})
+        # Manually submit searchterms to xloader to make a preview available
+        for resource in pkg.get("resources", []):
+            if (
+                resource.get("name") == TERMS_RSRC_NAME
+                and resource.get("state") == "active"
+                and not resource.get("datastore_active")
+            ):
+                resource_id = resource.get("id")
+                tk.get_action("xloader_submit")(
+                    site_user_context(),
+                    {"resource_id": resource_id, "ignore_hash": True},
+                )
+                log.info(
+                    "Enqueued xloader job for search terms resource {} for dataset {}".format(
+                        resource_id, dataset_id
+                    )
+                )
 
     return pkg
 

--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 
 # If resource is eligible, add terms job to worker queue
-def enqueue_terms_job(resource):
+def enqueue_terms_job(resource, resource_was_updated=False):
     # Check package_id exists to make sure it's not a package
     if (
         resource.get("name") == TERMS_RSRC_NAME
@@ -48,7 +48,7 @@ def enqueue_terms_job(resource):
     try:
         job = tk.enqueue_job(
             check_search_terms_resource,
-            [resource],
+            [resource, resource_was_updated],
             rq_kwargs={"timeout": 21600},
             queue="searchterms",
         )

--- a/ckanext/searchterms/jobs.py
+++ b/ckanext/searchterms/jobs.py
@@ -2,8 +2,12 @@ import os
 import logging
 import pandas as pd
 import uuid
+import datetime
+import json
 from werkzeug.datastructures import FileStorage
 import ckan.plugins.toolkit as tk
+import ckan.plugins as p
+import ckan.model as model
 from .constants import SearchtermsParsingError
 from .implementations import is_eligible, get_terms
 from .util import (
@@ -21,16 +25,48 @@ log = logging.getLogger(__name__)
 def enqueue_terms_job(resource):
     # Check package_id exists to make sure it's not a package
     if (
-        resource.get("name") != TERMS_RSRC_NAME
-        and resource.get("package_id", False)
-        and is_eligible(resource)
+        resource.get("name") == TERMS_RSRC_NAME
+        or not resource.get("package_id", False)
+        or not is_eligible(resource)
     ):
-        tk.enqueue_job(
+        return
+
+    res_id = resource.get("id")
+    task = {
+        "entity_id": res_id,
+        "entity_type": "resource",
+        "task_type": "searchterms",
+        "last_updated": str(datetime.datetime.utcnow()),
+        "state": "submitting",
+        "key": "searchterms",
+        "value": "{}",
+        "error": "{}",
+    }
+    p.toolkit.get_action("task_status_update")(
+        {"session": model.meta.create_local_session(), "ignore_auth": True}, task
+    )
+    try:
+        job = tk.enqueue_job(
             check_search_terms_resource,
             [resource],
             rq_kwargs={"timeout": 21600},
             queue="searchterms",
         )
+    except Exception:
+        log.exception("Unable to queue searchterms res_id=%s", res_id)
+
+    package_id = resource.get("package_id")
+    value = json.dumps(
+        {"job_id": job.id, "package_id": package_id, "resource_id": res_id}
+    )
+
+    task["value"] = value
+    task["state"] = "pending"
+    task["last_updated"] = str(datetime.datetime.utcnow())
+
+    p.toolkit.get_action("task_status_update")(
+        {"session": model.meta.create_local_session(), "ignore_auth": True}, task
+    )
 
 
 def enqueue_terms_update_on_delete_job(resource):
@@ -96,39 +132,82 @@ def check_search_terms_resource(resource, resource_was_updated=False):
     """
     Check for existing searchterms, update if it exists, otherwise create it
     """
-
-    dataset = tk.get_action("package_show")(
-        site_user_context(), {"id": resource.get("package_id")}
+    # Retrieve the existing task_status for this resource's searchterms job
+    res_id = resource.get("id")
+    existing_task = p.toolkit.get_action("task_status_show")(
+        site_user_context(),
+        {"entity_id": res_id, "task_type": "searchterms", "key": "searchterms"},
     )
-    rsrc_id = resource.get("id")
-    rsrc_col = "rsrc-{}".format(rsrc_id)
 
-    searchterms_df = None
-    # Get the search terms resource as a DataFrame, if it exists
-    log.info(f"Generating search terms for resource {resource.get('name')}")
-    searchterms_df, _ = get_existing_search_terms_df_from_csv(dataset)
+    # Update the task_status to 'running'
+    task = {
+        "id": existing_task.get("id"),
+        "entity_id": res_id,
+        "entity_type": "resource",
+        "task_type": "searchterms",
+        "last_updated": str(datetime.datetime.utcnow()),
+        "state": "running",
+        "key": "searchterms",
+        "value": existing_task.get("value", ""),
+        "error": "{}",
+    }
+    p.toolkit.get_action("task_status_update")(
+        {"session": model.meta.create_local_session(), "ignore_auth": True}, task
+    )
+
+    log = logging.getLogger(__name__)
+
     try:
-        new_terms_df = get_terms(resource, dataset, searchterms_df)
-        new_terms_df = create_initial_searchterms(rsrc_col, new_terms_df)
-    except SearchtermsParsingError as e:
-        return add_error(resource, str(e))
-    if searchterms_df is not None:
-        if resource_was_updated and rsrc_col in searchterms_df.columns:
-            searchterms_df = remove_resource_from_search_terms(rsrc_col, searchterms_df)
-        searchterms_df = update_searchterms(rsrc_col, new_terms_df, searchterms_df)
-        delete_existing_search_terms(resource)
-        new_column_order = [
-            *get_identifiercols(searchterms_df),
-            *get_termcols(searchterms_df),
-            *get_rsrccols(searchterms_df),
-            "search_index",
-        ]
-        searchterms_df = searchterms_df[new_column_order]
-    else:
-        searchterms_df = new_terms_df
-    searchterms_df = add_search_index_to_search_terms(searchterms_df)
-    save_file(searchterms_df, dataset.get("id"))
-    return searchterms_df
+        dataset = tk.get_action("package_show")(
+            site_user_context(), {"id": resource.get("package_id")}
+        )
+        rsrc_id = resource.get("id")
+        rsrc_col = "rsrc-{}".format(rsrc_id)
+
+        searchterms_df = None
+        # Get the search terms resource as a DataFrame, if it exists
+        log.info(f"Generating search terms for resource {resource.get('name')}")
+        searchterms_df, _ = get_existing_search_terms_df_from_csv(dataset)
+        try:
+            new_terms_df = get_terms(resource, dataset, searchterms_df)
+            new_terms_df = create_initial_searchterms(rsrc_col, new_terms_df)
+        except SearchtermsParsingError as e:
+            add_error(resource, str(e))
+            raise Exception(
+                f"Error parsing search terms for resource {resource.get('name')}"
+            )
+        if searchterms_df is not None:
+            if resource_was_updated and rsrc_col in searchterms_df.columns:
+                searchterms_df = remove_resource_from_search_terms(
+                    rsrc_col, searchterms_df
+                )
+            searchterms_df = update_searchterms(rsrc_col, new_terms_df, searchterms_df)
+            delete_existing_search_terms(resource)
+            new_column_order = [
+                *get_identifiercols(searchterms_df),
+                *get_termcols(searchterms_df),
+                *get_rsrccols(searchterms_df),
+                "search_index",
+            ]
+            searchterms_df = searchterms_df[new_column_order]
+        else:
+            searchterms_df = new_terms_df
+        searchterms_df = add_search_index_to_search_terms(searchterms_df)
+        save_file(searchterms_df, dataset.get("id"))
+
+        task["state"] = "complete"
+        task["error"] = "{}"
+        p.toolkit.get_action("task_status_update")(
+            {"session": model.meta.create_local_session(), "ignore_auth": True}, task
+        )
+        return searchterms_df
+    except Exception as e:
+        task["state"] = "error"
+        task["error"] = str(e)
+        log.error("searchterms error: {0}".format(str(e)))
+        p.toolkit.get_action("task_status_update")(
+            {"session": model.meta.create_local_session(), "ignore_auth": True}, task
+        )
 
 
 def create_initial_searchterms(rsrc_col, new_terms_df):

--- a/ckanext/searchterms/plugin.py
+++ b/ckanext/searchterms/plugin.py
@@ -7,9 +7,7 @@ from ckan import plugins
 import ckan.plugins.toolkit as tk
 import pandas as pd
 
-from .implementations import is_eligible
 from .jobs import (
-    check_search_terms_resource,
     enqueue_terms_job,
     enqueue_terms_update_on_delete_job,
 )


### PR DESCRIPTION
### Reason for change
Improve visibility of number of searchterm jobs and their status. I've also included the searchterm preview fix, which manually submits the searchterm resource to xloader after the code finishes uploading file to ckan. 

### How does your code work (if non-trivial)?
Adds searchterms job updates to task_status table with a somewhat similar flow to xloader. Flow of status updates:
1. When `enqueue_terms_job` is called, a new task entry is added to table with `submitting` status
2. After `enqueue_terms_job` finishes enqueuing, task status is updated to `pending`
3. When worker begins job (function `check_search_terms_resource`), task status is updated to `running`
4. If an exception is generated in this function, task status is updated to `error` and column `error` will contain the message
5. Otherwise, task status is updated to `complete`

To resubmit all packages for searchterms, you can run the following:
```
docker exec -t mecfs_ckan bash -c "ckan searchterms submit all"
```
This will also display the total number of validated packages and number of searchterm jobs submitted. In Postico, you can run the following query to filter for the searchterm jobs status. The time is in UTC
```
SELECT *
FROM task_status
WHERE task_type = 'searchterms'
  AND last_updated > '2025-01-09 17:00:00';
```